### PR TITLE
External links open in new window

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :jekyll_plugins do
   gem "jekyll-paginate"
   gem "jekyll-sitemap"
   gem "jekyll-seo-tag"
+  gem "jekyll-target-blank"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,9 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-target-blank (2.0.0)
+      jekyll (>= 3.0, < 5.0)
+      nokogiri (~> 1.10)
     jekyll-toc (0.15.0)
       jekyll (>= 3.8)
       nokogiri (~> 1.10)
@@ -98,6 +101,7 @@ DEPENDENCIES
   jekyll-redirect-from
   jekyll-seo-tag
   jekyll-sitemap
+  jekyll-target-blank
   jekyll-toc
   minima (~> 2.5)
   pry

--- a/_config.yml
+++ b/_config.yml
@@ -117,6 +117,7 @@ plugins:
   - jekyll-toc
   - jekyll-seo-tag
   - jekyll-sitemap
+  - jekyll-target-blank
 exclude:
   - Gemfile
   - Gemfile.lock


### PR DESCRIPTION
Use jekyll-target-blank to have all external links open in a new window, rather than the quite surprising behaviour of exiting you from the post.